### PR TITLE
Handle quoted-printable encoded content with CRCRLF as a line termina…

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -38,11 +38,6 @@ var testEncodings = []struct {
 		encoded: "Y2Fmw6k=",
 		decoded: "café",
 	},
-	{ // wild emails seen with a single = terminator and no crlf
-		enc:     "quoted-printable",
-		encoded: "=",
-		decoded: "",
-	},
 }
 
 func TestDecode(t *testing.T) {

--- a/quotedprintable/reader_test.go
+++ b/quotedprintable/reader_test.go
@@ -59,9 +59,12 @@ func TestTolerantReader(t *testing.T) {
 		{in: "foo=\nbar", want: "foobar"},
 		{in: "foo=\rbar", want: "foo", err: "quotedprintable: invalid hex byte 0x0d"},
 		{in: "foo=\r\r\r \nbar", want: "foo", err: `quotedprintable: invalid bytes after =: "\r\r\r \n"`},
+		{in: "foo=\r\r\n", want: "foo"},
 		// Issue 15486, accept trailing soft line-break at end of input.
 		{in: "foo=", want: "foo"},
-		{in: "=", want: "", err: `quotedprintable: invalid bytes after =: ""`},
+		// Tolerate lines that are just a space - seen in the wild where parts end in '='
+		// {in: "=", want: "", err: `quotedprintable: invalid bytes after =: ""`},
+		{in: "=", want: ""},
 
 		// Example from RFC 2045:
 		{in: "Now's the time =\n" + "for all folk to come=\n" + " to the aid of their country.",


### PR DESCRIPTION
…tor. Seen it in the wild from emails originating from Apple Mailer. Also remove some bad tests from a previous commit and make sure everything passes as expected (that code has been validated in the wild already).