### PR TITLE
fix: handle malformed headers with semicolon

### DIFF
--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -259,6 +259,20 @@ func TestReadHeaderWithoutBody(t *testing.T) {
 	}
 }
 
+const testInvalidHeadersWithSemicolon = `Content-Type:application/vnd.ms-excel;  name="20250225.xlsx"
+Content-Transfer-Encoding: base64
+Content-Disposition; attachment
+
+`
+
+func TestInvalidHeadersWithSemicolon(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(testInvalidHeadersWithSemicolon))
+	_, err := ReadHeader(r)
+	if err != nil {
+		t.Fatalf("readHeader() returned error: %v", err)
+	}
+}
+
 const testLFHeader = `From: contact@example.org
 To: contact@example.org
 Subject: A little message, just for you


### PR DESCRIPTION
Handles headers that are separated by either `:` (the correct separator according to the spec) or `;` (detected in https://thetalake.atlassian.net/jira/software/c/projects/INGSVC/boards/23?assignee=62ed7f4e3cc20c06c8afba85&selectedIssue=INGSVC-4809).

---
I replaced replaced this version in `email_preprocessor` locally and it passed the test I've created there with an example malformed `.eml` file.