### PR TITLE
textproto: tolerate multipart input ending without a closing boundary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/emersion/go-message
 
-go 1.18
+go 1.25.0
 
-require golang.org/x/text v0.14.0
+require golang.org/x/text v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=

--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -19,6 +19,11 @@ import (
 
 var emptyParams = make(map[string]string)
 
+// ErrMissingBoundaryClose is returned (joined with io.ErrUnexpectedEOF)
+// when the multipart input ends before the closing "--boundary--" delimiter
+// was found. The body bytes accumulated up to EOF are still delivered.
+var ErrMissingBoundaryClose = errors.New("multipart: missing closing boundary")
+
 // This constant needs to be at least 76 for this package to work correctly.
 // This is because \r\n--separator_of_len_70- would fill the buffer and it
 // wouldn't be safe to consume a single byte from it.
@@ -162,6 +167,12 @@ func scanUntilBoundary(buf, dashBoundary, nlDashBoundary []byte, total int64, re
 			}
 		}
 		if bytes.HasPrefix(dashBoundary, buf) {
+			if readErr != nil {
+				// EOF reached without ever seeing a boundary; flush the
+				// buffered bytes as body content rather than holding them
+				// back waiting for a boundary that will never arrive.
+				return len(buf), errors.Join(readErr, ErrMissingBoundaryClose)
+			}
 			return 0, readErr
 		}
 	}
@@ -178,6 +189,11 @@ func scanUntilBoundary(buf, dashBoundary, nlDashBoundary []byte, total int64, re
 		}
 	}
 	if bytes.HasPrefix(nlDashBoundary, buf) {
+		if readErr != nil {
+			// EOF reached and the buffered bytes are a possible boundary
+			// prefix; no boundary is coming, so deliver them as body.
+			return len(buf), errors.Join(readErr, ErrMissingBoundaryClose)
+		}
 		return 0, readErr
 	}
 
@@ -187,7 +203,16 @@ func scanUntilBoundary(buf, dashBoundary, nlDashBoundary []byte, total int64, re
 	// it too must be part of the body.
 	i := bytes.LastIndexByte(buf, nlDashBoundary[0])
 	if i >= 0 && bytes.HasPrefix(nlDashBoundary, buf[i:]) {
+		if readErr != nil {
+			// EOF reached and the buffered tail looks like a possible
+			// boundary prefix; deliver it as body since no boundary will
+			// follow.
+			return len(buf), errors.Join(readErr, ErrMissingBoundaryClose)
+		}
 		return i, nil
+	}
+	if readErr != nil {
+		return len(buf), errors.Join(readErr, ErrMissingBoundaryClose)
 	}
 	return len(buf), readErr
 }
@@ -230,6 +255,7 @@ type MultipartReader struct {
 
 	currentPart *Part
 	partsRead   int
+	done        bool
 
 	nl               []byte // "\r\n" or "\n" (set after seeing first boundary line)
 	nlDashBoundary   []byte // nl + "--boundary"
@@ -239,7 +265,30 @@ type MultipartReader struct {
 
 // NextPart returns the next part in the multipart or an error.
 // When there are no more parts, the error io.EOF is returned.
+//
+// NextPart terminates iteration only when the underlying stream is
+// unrecoverable: once it has returned an EOF-class error (any error
+// satisfying errors.Is(err, io.EOF) or errors.Is(err, io.ErrUnexpectedEOF)),
+// subsequent calls return io.EOF immediately. This guards callers against
+// infinite loops on streams whose underlying reader is sticky-errored
+// (for example, a multipart body that ends without its closing boundary).
+//
+// Per-part errors that leave the stream in a recoverable state (malformed
+// header lines, unexpected non-boundary lines between parts, etc.) are
+// returned without setting the sticky flag, so a caller can call NextPart
+// again to skip past the bad part and continue iterating.
 func (r *MultipartReader) NextPart() (*Part, error) {
+	if r.done {
+		return nil, io.EOF
+	}
+	p, err := r.nextPart()
+	if err != nil && (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) {
+		r.done = true
+	}
+	return p, err
+}
+
+func (r *MultipartReader) nextPart() (*Part, error) {
 	if r.currentPart != nil {
 		r.currentPart.Close()
 	}
@@ -259,7 +308,7 @@ func (r *MultipartReader) NextPart() (*Part, error) {
 			return nil, io.EOF
 		}
 		if err != nil {
-			return nil, fmt.Errorf("multipart: NextPart: %v", err)
+			return nil, fmt.Errorf("multipart: NextPart: %w", err)
 		}
 
 		if r.isBoundaryDelimiterLine(line) {

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -7,6 +7,7 @@ package textproto
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -284,7 +285,7 @@ Oh no, premature EOF!
 		t.Fatalf("didn't get a part")
 	}
 	_, err = io.Copy(ioutil.Discard, part)
-	if err != io.ErrUnexpectedEOF {
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("expected error io.ErrUnexpectedEOF; got %v", err)
 	}
 }
@@ -851,5 +852,425 @@ func TestNoBoundary(t *testing.T) {
 	_, err := mr.NextPart()
 	if got, want := fmt.Sprint(err), "multipart: boundary is empty"; got != want {
 		t.Errorf("NextPart error = %v; want %v", got, want)
+	}
+}
+
+// TestMissingBoundaryCloseTrailingCRLF verifies that when the multipart
+// input ends without a closing "--boundary--" delimiter, trailing bytes of
+// the part body (including a final CRLF) are still delivered to the caller
+// rather than silently truncated.
+func TestMissingBoundaryCloseTrailingCRLF(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if want := []byte("hello\r\n"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+}
+
+// TestMissingBoundaryCloseNoTrailingNewline verifies that body bytes with no
+// trailing newline are also delivered when the closing boundary is absent.
+func TestMissingBoundaryCloseNoTrailingNewline(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if want := []byte("hello"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+}
+
+// TestNextPartEOFWraps verifies that NextPart wraps the underlying read
+// error using %w so errors.Is identity is preserved through the wrap. After
+// the previous part's body is fully drained, the bufReader is empty and the
+// next ReadSlice returns plain io.EOF (not io.ErrUnexpectedEOF). The wrapped
+// error must still satisfy errors.Is(err, io.EOF). This exercises the change
+// from fmt.Errorf("...: %v", err) to "...: %w", err.
+func TestNextPartEOFWraps(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	if _, err := io.ReadAll(part); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("first part read err = %v; want io.ErrUnexpectedEOF", err)
+	}
+	_, err = r.NextPart()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("second NextPart err = %v; errors.Is(err, io.EOF) = false", err)
+	}
+}
+
+// TestMissingBoundaryCloseDashDashOnlyBody covers the total == 0 EOF-flush
+// branch of scanUntilBoundary. With boundary "A", dashBoundary is "--A".
+// A part body of exactly "--" (a strict prefix of dashBoundary) followed by
+// EOF must be flushed as body bytes rather than held back waiting for a
+// boundary that never arrives.
+func TestMissingBoundaryCloseDashDashOnlyBody(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"--"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if want := []byte("--"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+}
+
+// TestTrailingExactDashBoundaryRecognizedAtEOF guards a pre-existing parser
+// behavior against accidental capture by the new EOF-flush branches: when
+// the buffer at EOF is exactly "\r\n--A" (no trailing "--"), matchAfterPrefix
+// returns +1 because len(buf) == len(prefix) and readErr != nil, so the
+// existing boundary-detection path consumes those bytes as a boundary match.
+func TestTrailingExactDashBoundaryRecognizedAtEOF(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\r\n--A"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if err != nil {
+		t.Errorf("io.ReadAll: %v; want nil", err)
+	}
+	if want := []byte("hello"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	_, err = r.NextPart()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("second NextPart err = %v; errors.Is(err, io.EOF) = false", err)
+	}
+}
+
+// TestMissingBoundaryCloseLFOnly verifies the missing-close fix in the
+// LF-only line-ending mode. The parser auto-switches to "\n--boundary"
+// (no CR) when the opening boundary line ends in just "\n".
+func TestMissingBoundaryCloseLFOnly(t *testing.T) {
+	body := "--A\n" +
+		"Content-Type: text/plain\n" +
+		"\n" +
+		"hello\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if want := []byte("hello\n"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+}
+
+// TestMissingBoundaryCloseInnerNested verifies the fix at an inner level
+// when wrapped by a well-formed outer multipart. The outer multipart has a
+// proper closing "--OUTER--", but its single child (itself a multipart with
+// boundary INNER) lacks "--INNER--". Reading the inner text/plain part's
+// body must surface the joined io.ErrUnexpectedEOF + ErrMissingBoundaryClose
+// error, and the next inner NextPart call must return a wrapped io.EOF.
+func TestMissingBoundaryCloseInnerNested(t *testing.T) {
+	body := "--OUTER\r\n" +
+		"Content-Type: multipart/mixed; boundary=INNER\r\n" +
+		"\r\n" +
+		"--INNER\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"nested\r\n" +
+		"\r\n--OUTER--\r\n"
+	outer := NewMultipartReader(strings.NewReader(body), "OUTER")
+	outerPart, err := outer.NextPart()
+	if err != nil {
+		t.Fatalf("outer NextPart: %v", err)
+	}
+	inner := NewMultipartReader(outerPart, "INNER")
+	innerPart, err := inner.NextPart()
+	if err != nil {
+		t.Fatalf("inner NextPart: %v", err)
+	}
+	got, err := io.ReadAll(innerPart)
+	if want := []byte("nested\r\n"); !bytes.Equal(got, want) {
+		t.Errorf("inner body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+	_, err = inner.NextPart()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("second inner NextPart err = %v; errors.Is(err, io.EOF) = false", err)
+	}
+}
+
+// TestNextPartStickyAfterMissingClose verifies that once NextPart has
+// surfaced an error from the underlying parser, the sticky termination
+// kicks in and subsequent calls return the bare io.EOF sentinel without
+// re-entering the parser. The first errored call still returns the parser's
+// own error verbatim (here a fmt-wrapped io.EOF from the bufReader hitting
+// EOF without seeing a final boundary line), satisfying errors.Is.
+func TestNextPartStickyAfterMissingClose(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if want := []byte("hello\r\n"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+	if _, err := r.NextPart(); !errors.Is(err, io.EOF) {
+		t.Errorf("second NextPart err = %v; errors.Is(err, io.EOF) = false", err)
+	}
+	if _, err := r.NextPart(); err != io.EOF {
+		t.Errorf("third NextPart err = %v; want bare io.EOF (sticky termination)", err)
+	}
+}
+
+// TestNextPartEmptyBoundaryNotSticky verifies that an empty-boundary
+// configuration error is NOT sticky: it is a non-EOF error, so the same
+// error is returned on every call. The sticky termination only engages
+// for EOF-class errors where the underlying stream is unrecoverable.
+func TestNextPartEmptyBoundaryNotSticky(t *testing.T) {
+	r := NewMultipartReader(strings.NewReader(""), "")
+	for i := 0; i < 3; i++ {
+		_, err := r.NextPart()
+		if got, want := fmt.Sprint(err), "multipart: boundary is empty"; got != want {
+			t.Errorf("call %d: NextPart err = %v; want %v", i+1, got, want)
+		}
+	}
+}
+
+// TestNextPartStickyAfterCleanEOF verifies that the sticky-done logic does
+// not interfere with the well-formed end-of-iteration path: after the normal
+// io.EOF, subsequent calls continue to return io.EOF.
+func TestNextPartStickyAfterCleanEOF(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\r\n" +
+		"--A--\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, err := io.ReadAll(part)
+	if err != nil {
+		t.Errorf("io.ReadAll: %v; want nil", err)
+	}
+	if want := []byte("hello"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if _, err := r.NextPart(); err != io.EOF {
+		t.Errorf("second NextPart err = %v; want io.EOF", err)
+	}
+	if _, err := r.NextPart(); err != io.EOF {
+		t.Errorf("third NextPart err = %v; want io.EOF", err)
+	}
+}
+
+// TestNextPartStickyEngagesMidIteration covers sticky engagement on a
+// NextPart call after an earlier part was read cleanly. An earlier part's
+// clean read must not pre-arm sticky, but a later EOF-class error must.
+func TestNextPartStickyEngagesMidIteration(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"first\r\n" +
+		"--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"second\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+
+	part1, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("first NextPart: %v", err)
+	}
+	got1, err := io.ReadAll(part1)
+	if err != nil {
+		t.Errorf("part1 io.ReadAll err = %v; want nil", err)
+	}
+	if want := []byte("first"); !bytes.Equal(got1, want) {
+		t.Errorf("part1 body = %q; want %q", got1, want)
+	}
+
+	part2, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("second NextPart: %v", err)
+	}
+	got2, err := io.ReadAll(part2)
+	if want := []byte("second\r\n"); !bytes.Equal(got2, want) {
+		t.Errorf("part2 body = %q; want %q", got2, want)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+
+	if _, err := r.NextPart(); !errors.Is(err, io.EOF) {
+		t.Errorf("third NextPart err = %v; errors.Is(err, io.EOF) = false", err)
+	}
+	if _, err := r.NextPart(); err != io.EOF {
+		t.Errorf("fourth NextPart err = %v; want bare io.EOF (sticky engaged)", err)
+	}
+}
+
+// TestNextPartStickyDoesNotPoisonPriorPart confirms that the sticky done
+// flag lives on MultipartReader, not on *Part: after sticky termination has
+// engaged on the reader, calling Read on a previously-returned *Part still
+// idempotently surfaces that part's terminal error rather than being
+// hijacked by the reader-level short-circuit.
+func TestNextPartStickyDoesNotPoisonPriorPart(t *testing.T) {
+	body := "--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+	part, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("NextPart: %v", err)
+	}
+	got, readErr := io.ReadAll(part)
+	if want := []byte("hello\r\n"); !bytes.Equal(got, want) {
+		t.Errorf("body bytes = %q; want %q", got, want)
+	}
+	if !errors.Is(readErr, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(readErr, io.ErrUnexpectedEOF) = false; err = %v", readErr)
+	}
+	if !errors.Is(readErr, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(readErr, ErrMissingBoundaryClose) = false; err = %v", readErr)
+	}
+
+	// Drive sticky termination on the MultipartReader: the first call after
+	// a malformed end returns a wrapped EOF (which engages sticky); the
+	// second returns bare io.EOF via the short-circuit.
+	if _, err := r.NextPart(); !errors.Is(err, io.EOF) {
+		t.Fatalf("second NextPart err = %v; errors.Is(err, io.EOF) = false", err)
+	}
+	if _, err := r.NextPart(); err != io.EOF {
+		t.Fatalf("third NextPart err = %v; want bare io.EOF (sticky engaged)", err)
+	}
+
+	// Reading the originally-returned *Part again must still surface the
+	// previously observed terminal error, proving done is on MultipartReader,
+	// not on *Part.
+	buf := make([]byte, 8)
+	n, err := part.Read(buf)
+	if n != 0 {
+		t.Errorf("part.Read after sticky: n = %d; want 0", n)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("errors.Is(err, io.ErrUnexpectedEOF) = false; err = %v", err)
+	}
+	if !errors.Is(err, ErrMissingBoundaryClose) {
+		t.Errorf("errors.Is(err, ErrMissingBoundaryClose) = false; err = %v", err)
+	}
+}
+
+// TestNextPartRecoversAfterMalformedHeader verifies that non-EOF errors do
+// NOT engage sticky termination: the parser walks forward through malformed
+// content, surfacing distinct non-EOF errors per call, until it eventually
+// reaches the closing boundary and returns bare io.EOF (engaging sticky).
+//
+// Specific error messages from the parser state machine are intentionally
+// not asserted; the test only verifies structural facts (each errored call
+// before the final EOF is non-nil and not EOF-class, then a bare io.EOF,
+// then sticky stays engaged).
+func TestNextPartRecoversAfterMalformedHeader(t *testing.T) {
+	body := "--A\r\n" +
+		"--A\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"recovered\r\n" +
+		"--A--\r\n"
+	r := NewMultipartReader(strings.NewReader(body), "A")
+
+	const maxIters = 10
+	var firstEOFAt = -1
+	for i := 0; i < maxIters; i++ {
+		_, err := r.NextPart()
+		if err == nil {
+			t.Fatalf("iter %d: NextPart err = nil; expected a parser error or io.EOF", i)
+		}
+		if err == io.EOF {
+			firstEOFAt = i
+			break
+		}
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("iter %d: NextPart err = %v; sticky engaged before reaching closing boundary", i, err)
+		}
+	}
+	if firstEOFAt < 0 {
+		t.Fatalf("never reached io.EOF within %d iterations; parser failed to make forward progress", maxIters)
+	}
+	if firstEOFAt < 1 {
+		t.Errorf("reached io.EOF on iter %d; expected at least one non-EOF error first to prove forward progress", firstEOFAt)
+	}
+
+	// Sticky must stay engaged on subsequent calls.
+	if _, err := r.NextPart(); err != io.EOF {
+		t.Errorf("post-EOF NextPart err = %v; want bare io.EOF (sticky engaged)", err)
 	}
 }


### PR DESCRIPTION
When a multipart body ended without "--boundary--", scanUntilBoundary silently dropped trailing bytes that were held back as a possible boundary prefix. Once the underlying reader hit EOF those bytes could no longer be the start of a real boundary, but they were never flushed to the caller. Downstream decoders (e.g. quoted-printable) would then see a truncated body and fail; in particular a body ending with "=\r\n" lost the trailing CRLF and the QP decoder reported "invalid bytes after =".

Flush those bytes at EOF and report the condition via a new sentinel ErrMissingBoundaryClose joined with io.ErrUnexpectedEOF, so callers can distinguish a truly malformed end-of-body from other unexpected EOFs while still matching errors.Is(err, io.ErrUnexpectedEOF). NextPart wraps its underlying error with %w so errors.Is identity is preserved through the wrap.

Also make NextPart terminate cleanly once the stream is exhausted. Once it returns an EOF-class error (any error satisfying errors.Is(err, io.EOF) or errors.Is(err, io.ErrUnexpectedEOF)), set a done flag and return io.EOF directly on subsequent calls. Without this, naive iteration loops that classified the wrapped NextPart error and continued past it would call NextPart indefinitely, each call returning the same wrapped error; callers using errors.Is were fine, but those using string matching could spin until a safety limit kicked in. NextPart's contract now mirrors bufio.Scanner for the EOF case. Per-part errors that do NOT signal stream exhaustion (malformed header lines, unexpected non-boundary lines between parts, empty boundary) are returned without the sticky flag, so callers can call NextPart again to skip past a bad part and reach the next valid one. Body reads on a previously returned *Part are unaffected; only NextPart itself is gated.

Bump the go directive to 1.25.0 (errors.Join requires 1.20+) and refresh golang.org/x/text accordingly.